### PR TITLE
modify: Notice: S3 - Changes to Defaults (Block Public Access and ACL's)

### DIFF
--- a/modules/infrastructure/cloudtrail/s3.tf
+++ b/modules/infrastructure/cloudtrail/s3.tf
@@ -35,10 +35,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
 
 
 resource "aws_s3_bucket_acl" "cloudtrail" {
-  bucket = aws_s3_bucket.cloudtrail.id
-  acl    = "private"
+  bucket     = aws_s3_bucket.cloudtrail.id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
 }
 
+# Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  bucket = aws_s3_bucket.cloudtrail.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
 
 # --------------------------
 # iam, acl


### PR DESCRIPTION
Recently I tried to deploy an example resource using Terraform, and received the error:

Error: error creating S3 bucket ACL for bucket-name: AccessControlListNotSupported: The bucket does not allow ACLs │ status code: 400

so I tried to fix it

reference:
https://stackoverflow.com/questions/76049290/error-accesscontrollistnotsupported-when-trying-to-create-a-bucket-acl-in-aws