### PR TITLE
fix S3 ACL issue

### DIFF
--- a/modules/infrastructure/cloudtrail/main.tf
+++ b/modules/infrastructure/cloudtrail/main.tf
@@ -34,6 +34,16 @@ resource "aws_cloudtrail" "cloudtrail" {
 
   tags = var.tags
 
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3"]
+    }
+  }
+
   ## note: seems required to avoid raicing conditions (InsufficientSnsTopicPolicyException on cloudtrail creation) /shrug
   depends_on = [aws_s3_bucket_policy.cloudtrail_s3, aws_sns_topic_policy.allow_cloudtrail_publish]
 }

--- a/modules/infrastructure/cloudtrail/s3.tf
+++ b/modules/infrastructure/cloudtrail/s3.tf
@@ -33,12 +33,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
   }
 }
 
-
-resource "aws_s3_bucket_acl" "cloudtrail" {
+resource "aws_s3_bucket_ownership_controls" "owner_enforced" {
   bucket = aws_s3_bucket.cloudtrail.id
-  acl    = "private"
-}
 
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
 
 # --------------------------
 # iam, acl


### PR DESCRIPTION
Fix ACL issue based on this PR to original Sysdig terraform module - https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/pull/167/files

Since April 2023 All new S3 buckets are created with disabled public access - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

and we just needed to make sure bucket ownership control is set to BucketOwnerEnforced

this was tested and works fine.